### PR TITLE
fix: 🐛 production環境でサーバエラーになる現象を修正

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -10,7 +10,7 @@ Rails.application.configure do
   # your application in memory, allowing both threaded web servers
   # and those relying on copy on write to perform better.
   # Rake tasks automatically ignore this option for performance.
-  config.eager_load = true
+  config.eager_load = false
 
   # Full error reports are disabled and caching is turned on.
   config.consider_all_requests_local       = false


### PR DESCRIPTION
- ワークアラウンド

```bash
2022-04-11T06:34:46.179850+00:00 app[web.1]: => Booting Puma
2022-04-11T06:34:46.179865+00:00 app[web.1]: => Rails 6.1.5 application starting in production
2022-04-11T06:34:46.179865+00:00 app[web.1]: => Run `bin/rails server --help` for more startup options
2022-04-11T06:34:47.088181+00:00 app[web.1]: Exiting
2022-04-11T06:34:47.092654+00:00 app[web.1]: /app/vendor/bundle/ruby/3.1.0/gems/actionmailer-6.1.5/lib/action_mailer.rb:61:in `eager_load!': undefined method `eager_autoload!' for Mail:Module (NoMethodError)
2022-04-11T06:34:47.092657+00:00 app[web.1]:
2022-04-11T06:34:47.092657+00:00 app[web.1]: Mail.eager_autoload!
2022-04-11T06:34:47.092658+00:00 app[web.1]: ^^^^^^^^^^^^^^^^
```