### PR TITLE
fix: 🐛 Dockerfile で Node.js を落とせなくなってしまったので "n" で管理する方法に修正した

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,14 +1,10 @@
 FROM ruby:3.2.2
 ENV LANG C.UTF-8
-ARG NODEJS_MAJOR_VERSION=16.x
-ARG NODEJS_PATCH_VERSION=16.19.0
+ARG NODEJS_VERSION=16.19.0
 ARG YARN_VERSION=1.22.19
 
 RUN apt update -qq && apt install -y build-essential libpq-dev
-RUN curl -o nodejs.deb https://deb.nodesource.com/node_$NODEJS_MAJOR_VERSION/pool/main/n/nodejs/nodejs_$NODEJS_PATCH_VERSION-deb-1nodesource1_amd64.deb && \
-    apt install -y ./nodejs.deb && \
-    rm nodejs.deb
-RUN npm install -g yarn@$YARN_VERSION
+RUN apt install -y nodejs npm && npm install -g n && n $NODEJS_VERSION && npm install -g yarn@$YARN_VERSION
 RUN gem install bundler
 
 RUN mkdir /myapp


### PR DESCRIPTION
This pull request updates the `Dockerfile` to simplify the installation process for Node.js and Yarn. The changes replace the use of specific Node.js version arguments and manual installation steps with a more streamlined approach using the `n` Node.js version manager.

### Simplification of Node.js and Yarn installation:

* [`Dockerfile`](diffhunk://#diff-dd2c0eb6ea5cfc6c4bd4eac30934e2d5746747af48fef6da689e85b752f39557L3-R7): Removed the `NODEJS_MAJOR_VERSION` and `NODEJS_PATCH_VERSION` arguments and replaced them with a single `NODEJS_VERSION` argument. Simplified the Node.js installation process by using the `n` version manager instead of manually downloading and installing a `.deb` package. The Yarn installation remains unchanged but is now integrated into the updated process.