### PR TITLE
ci: 🎡 外部アクションのバージョンをアップデートした

### DIFF
--- a/.github/workflows/build_docker_image.yml
+++ b/.github/workflows/build_docker_image.yml
@@ -35,8 +35,11 @@ jobs:
           --health-timeout 5s
           --health-retries 5
     steps:
-      - name: ソースコードをチェックアウトする
-        uses: actions/checkout@v3
+      - name: $ git clone する
+        # https://github.com/actions/checkout/releases
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          persist-credentials: false
       - name: Docker イメージ をビルドする
         env:
           DOCKER_BUILDKIT: 1 # '# syntax = docker/dockerfile:1.2' は不要だが、この指定は 2023/01/23 現在、必須

--- a/.github/workflows/config.yml
+++ b/.github/workflows/config.yml
@@ -69,11 +69,12 @@ jobs:
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           persist-credentials: false
-      - name: GCP の認証を行う
-        uses: google-github-actions/auth@v1
+      - name: Google Cloud の認証を行う
+        # https://github.com/google-github-actions/auth/releases
+        uses: google-github-actions/auth@71f986410dfbc7added4569d411d040a91dc6935 # v2.1.8
         with:
           credentials_json: ${{ secrets.GCP_SERVICE_ACCOUNT_CREDENTIALS }}
-      - name: GCP の CLI の認証を行う
+      - name: Google Cloud の CLI の認証を行う
         run: |
           gcloud auth configure-docker ${{ env.GCP_AUTH_HOST }}
       - name: Docker イメージ をビルドする
@@ -86,8 +87,9 @@ jobs:
       - name: Docker イメージ をプッシュする
         run: |
           docker push ${{ env.DOCKER_IMAGE }}
-      - name: Deploy to Cloud Run
-        uses: google-github-actions/deploy-cloudrun@v1
+      - name: Cloud Run にデプロイする
+        # https://github.com/google-github-actions/deploy-cloudrun/releases
+        uses: google-github-actions/deploy-cloudrun@9c5864eab7354d2e132307e685a2272655932799 # v2.7.3
         with:
           service: ${{ env.CLOUD_RUN_SERVICE_NAME }}
           image: ${{ env.DOCKER_IMAGE }}


### PR DESCRIPTION
This pull request updates several GitHub Actions workflows to use specific versions of actions and improves clarity by renaming steps in Japanese. The most important changes include pinning action versions for better reproducibility and updating step names for consistency and readability.

### Workflow Improvements:

* [`.github/workflows/build_docker_image.yml`](diffhunk://#diff-cf9e37f38163766aa65e6d1700f69a4e5ba1792bee8378ed5dd63d883df42243L38-R42): Updated the `actions/checkout` step to use a pinned version (`@11bd71901bbe5b1630ceea73d27597364c9af683`) and renamed the step from "ソースコードをチェックアウトする" to "$ git clone する" for clearer intent.

* [`.github/workflows/config.yml`](diffhunk://#diff-33cc4c925f7fd36575f5e5b61d1e9c942fea5189e2c67d09720d714e19151404L72-R77): Updated the `google-github-actions/auth` step to use a pinned version (`@71f986410dfbc7added4569d411d040a91dc6935`) and renamed the step from "GCP の認証を行う" to "Google Cloud の認証を行う" for consistency.

* [`.github/workflows/config.yml`](diffhunk://#diff-33cc4c925f7fd36575f5e5b61d1e9c942fea5189e2c67d09720d714e19151404L89-R92): Updated the `google-github-actions/deploy-cloudrun` step to use a pinned version (`@9c5864eab7354d2e132307e685a2272655932799`) and renamed the step from "Deploy to Cloud Run" to "Cloud Run にデプロイする" for better alignment with other steps.