### PR TITLE
feat: 🎸 Ruby 3.4 で Obsolete となる "bigdecimal" gem を明示的に記載した

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -13,6 +13,7 @@ gem 'active_model_serializers'
 gem 'activerecord-import'
 gem 'annotate'
 gem 'base64'
+gem 'bigdecimal'
 gem 'bootsnap', require: false
 gem 'brakeman'
 gem 'bullet'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -99,6 +99,7 @@ GEM
       erubi (>= 1.0.0)
       rack (>= 0.9.0)
       rouge (>= 1.0.0)
+    bigdecimal (3.1.9)
     bindex (0.8.1)
     binding_of_caller (1.0.1)
       debug_inspector (>= 1.2.0)
@@ -671,6 +672,7 @@ DEPENDENCIES
   awesome_print
   base64
   better_errors
+  bigdecimal
   binding_of_caller
   bootsnap
   brakeman


### PR DESCRIPTION
This pull request includes a small update to the `Gemfile`. The change adds the `bigdecimal` gem to the project dependencies.