### PR TITLE
ci: 🎡 Ubuntu の Runner のバージョンを 24.04 に上げた

### DIFF
--- a/.github/workflows/build_docker_image.yml
+++ b/.github/workflows/build_docker_image.yml
@@ -20,7 +20,7 @@ env:
 jobs:
   build_docker_image:
     name: Docker イメージ をビルドできるかどうか
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     services:
       postgres:
         image: postgres:15.4

--- a/.github/workflows/config.yml
+++ b/.github/workflows/config.yml
@@ -23,7 +23,7 @@ env:
 jobs:
   rails_app_test:
     name: Rails アプリのテスト
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     services:
       postgres:
         image: postgres:15.4
@@ -62,7 +62,7 @@ jobs:
     needs: rails_app_test
     if: ${{ github.ref_name == 'main' }}
     name: Cloud Run に production デプロイする
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - name: $ git clone する
         # https://github.com/actions/checkout/releases


### PR DESCRIPTION
This pull request updates the GitHub Actions workflows to use a newer Ubuntu version for the runner environment. The changes ensure consistency across workflows and prepare the CI/CD pipelines for the latest Ubuntu features and updates.

### Workflow environment updates:

* [`.github/workflows/build_docker_image.yml`](diffhunk://#diff-cf9e37f38163766aa65e6d1700f69a4e5ba1792bee8378ed5dd63d883df42243L23-R23): Updated the `runs-on` parameter from `ubuntu-22.04` to `ubuntu-24.04` in the `build_docker_image` job.
* [`.github/workflows/config.yml`](diffhunk://#diff-33cc4c925f7fd36575f5e5b61d1e9c942fea5189e2c67d09720d714e19151404L26-R26): Updated the `runs-on` parameter from `ubuntu-22.04` to `ubuntu-24.04` in the `rails_app_test` job.
* [`.github/workflows/config.yml`](diffhunk://#diff-33cc4c925f7fd36575f5e5b61d1e9c942fea5189e2c67d09720d714e19151404L65-R65): Updated the `runs-on` parameter from `ubuntu-22.04` to `ubuntu-24.04` in the `Cloud Run` deployment job.