### PR TITLE
$ bundle update ruby-concurrent

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -155,7 +155,7 @@ GEM
     chartkick (5.1.5)
     chronic (0.10.2)
     coderay (1.1.3)
-    concurrent-ruby (1.2.3)
+    concurrent-ruby (1.3.5)
     connection_pool (2.5.1)
     content_disposition (1.0.0)
     crack (0.4.5)
@@ -764,4 +764,4 @@ RUBY VERSION
    ruby 3.4.3p32
 
 BUNDLED WITH
-   2.3.11
+   2.6.7


### PR DESCRIPTION
Without `--conservative`

```bash
$ bundle update ruby-concurrent
```

cf. #763 