### PR TITLE
Update "concurrent-ruby" gem to v1.3.4

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -18,6 +18,8 @@ gem 'bootsnap', require: false
 gem 'bullet'
 gem 'bundler-audit'
 gem 'chartkick'
+# https://github.com/facebook/react-native/issues/48746#issuecomment-2602408458
+gem 'concurrent-ruby', '1.3.4'
 gem 'csv'
 gem 'default_value_for'
 gem 'devise'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -155,7 +155,7 @@ GEM
     chartkick (5.1.5)
     chronic (0.10.2)
     coderay (1.1.3)
-    concurrent-ruby (1.2.3)
+    concurrent-ruby (1.3.4)
     connection_pool (2.5.1)
     content_disposition (1.0.0)
     crack (0.4.5)
@@ -696,6 +696,7 @@ DEPENDENCIES
   capistrano3-unicorn
   capybara
   chartkick
+  concurrent-ruby (= 1.3.4)
   csv
   database_cleaner
   database_rewinder


### PR DESCRIPTION
- 最新の v1.3.5 だと落ちるので、[こちら](https://github.com/facebook/react-native/issues/48746#issuecomment-2602408458) を参考にして `v1.3.4` で止めた
    - 理由は調べていないが、Rails のバージョンとの関連がありそう 

- `v1.3.5` だと落ちるので、その Pull Request は閉じる
    - close https://github.com/true-runes/suikoden-election-2018/pull/800
    - close https://github.com/true-runes/suikoden-election-2018/pull/763 