### PR TITLE
feat: 🎸 Node.js のバージョンに関わらず assets:precompile できるようにオプションを追加した

### DIFF
--- a/.github/workflows/build_docker_image.yml
+++ b/.github/workflows/build_docker_image.yml
@@ -46,4 +46,4 @@ jobs:
           RAILS_MASTER_KEY: ${{ secrets.RAILS_MASTER_KEY }}
           SECRET_KEY_BASE: ${{ secrets.SECRET_KEY_BASE }}
         run: |
-          docker build --secret id=rails_master_key,env=RAILS_MASTER_KEY --secret id=secret_key_base,env=SECRET_KEY_BASE --tag ${{ env.DOCKER_IMAGE }} .
+          docker build --build-arg NODEJS_VERSION=$(cat .node-version) --secret id=rails_master_key,env=RAILS_MASTER_KEY --secret id=secret_key_base,env=SECRET_KEY_BASE --tag ${{ env.DOCKER_IMAGE }} .

--- a/.github/workflows/config.yml
+++ b/.github/workflows/config.yml
@@ -87,7 +87,7 @@ jobs:
           RAILS_MASTER_KEY: ${{ secrets.RAILS_MASTER_KEY }}
           SECRET_KEY_BASE: ${{ secrets.SECRET_KEY_BASE }}
         run: |
-          docker build --secret id=rails_master_key,env=RAILS_MASTER_KEY --secret id=secret_key_base,env=SECRET_KEY_BASE --tag ${{ env.DOCKER_IMAGE }} .
+          docker build --build-arg NODEJS_VERSION=$(cat .node-version) --secret id=rails_master_key,env=RAILS_MASTER_KEY --secret id=secret_key_base,env=SECRET_KEY_BASE --tag ${{ env.DOCKER_IMAGE }} .
       - name: Docker イメージ をプッシュする
         run: |
           docker push ${{ env.DOCKER_IMAGE }}

--- a/.github/workflows/config.yml
+++ b/.github/workflows/config.yml
@@ -49,6 +49,10 @@ jobs:
         with:
           ruby-version: .ruby-version
           bundler-cache: true
+      - name: assets:precompile を行う (NODE_OPTIONS="--openssl-legacy-provider")
+        # TODO: NODE_OPTIONS="--openssl-legacy-provider" は一時的な回避策なので、将来的には削除すべきである
+        run: |
+          RAILS_MASTER_KEY=${{ secrets.RAILS_MASTER_KEY }} NODE_OPTIONS="--openssl-legacy-provider" bundle exec rails assets:precompile
       - name: データベースをセットアップする
         run: |
           bin/rails db:create

--- a/.gitignore
+++ b/.gitignore
@@ -29,6 +29,7 @@ coverage/
 spec/tmp
 .rspec
 start_unicorn.sh
+/public/assets
 /public/packs
 /public/packs-test
 /node_modules

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM ruby:3.4.3
 ENV LANG C.UTF-8
-ARG NODEJS_VERSION=$(cat .node-version)
+ARG NODEJS_VERSION
 
 RUN apt update -qq && apt install -y build-essential libpq-dev
 # NOTE: Yarn のバージョン指定をすることも可能だが、ここでは行わない（将来的に行うかもしれない）

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,10 @@
 FROM ruby:3.4.3
 ENV LANG C.UTF-8
 ARG NODEJS_VERSION=$(cat .node-version)
-ARG YARN_VERSION=1.22.19
 
 RUN apt update -qq && apt install -y build-essential libpq-dev
-RUN apt install -y nodejs npm && npm install -g n && n $NODEJS_VERSION && npm install -g yarn@$YARN_VERSION
+# NOTE: Yarn のバージョン指定をすることも可能だが、ここでは行わない（将来的に行うかもしれない）
+RUN apt install -y nodejs npm && npm install -g n && n $NODEJS_VERSION && npm install -g yarn
 RUN gem install bundler
 
 RUN mkdir /myapp

--- a/Dockerfile
+++ b/Dockerfile
@@ -20,7 +20,8 @@ RUN bundle install
 COPY . /myapp
 
 # production ビルド前提になっている
-RUN --mount=type=secret,id=rails_master_key RAILS_ENV=production RAILS_MASTER_KEY=$(cat /run/secrets/rails_master_key) bin/rails assets:precompile
+# TODO: NODE_OPTIONS="--openssl-legacy-provider" は一時的な回避策なので、将来的には削除すべきである
+RUN --mount=type=secret,id=rails_master_key RAILS_ENV=production RAILS_MASTER_KEY=$(cat /run/secrets/rails_master_key) NODE_OPTIONS="--openssl-legacy-provider" bin/rails assets:precompile
 
 # Add a script to be executed every time the container starts.
 COPY entrypoint.sh /usr/bin/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM ruby:3.4.3
 ENV LANG C.UTF-8
-ARG NODEJS_VERSION=16.19.0
+ARG NODEJS_VERSION=$(cat .node-version)
 ARG YARN_VERSION=1.22.19
 
 RUN apt update -qq && apt install -y build-essential libpq-dev


### PR DESCRIPTION
This pull request introduces several updates to the Docker build process and related workflows to improve compatibility and streamline the setup. Key changes include adding support for dynamic Node.js versioning, introducing a temporary workaround for OpenSSL compatibility issues, and simplifying Yarn version management.

### Workflow updates:

* [`.github/workflows/build_docker_image.yml`](diffhunk://#diff-cf9e37f38163766aa65e6d1700f69a4e5ba1792bee8378ed5dd63d883df42243L49-R49): Added a `--build-arg` to dynamically set the Node.js version during the Docker build process by reading the version from the `.node-version` file.
* [`.github/workflows/config.yml`](diffhunk://#diff-33cc4c925f7fd36575f5e5b61d1e9c942fea5189e2c67d09720d714e19151404R52-R55): Introduced a new step to precompile assets with the `NODE_OPTIONS="--openssl-legacy-provider"` workaround to address OpenSSL compatibility issues. This is marked as a temporary solution.

### Dockerfile updates:

* [`Dockerfile`](diffhunk://#diff-dd2c0eb6ea5cfc6c4bd4eac30934e2d5746747af48fef6da689e85b752f39557L3-R7): Removed the hardcoded Yarn version, allowing for flexibility in Yarn version management. A note was added indicating that version specification might be reintroduced in the future.
* [`Dockerfile`](diffhunk://#diff-dd2c0eb6ea5cfc6c4bd4eac30934e2d5746747af48fef6da689e85b752f39557L23-R24): Updated the `assets:precompile` step to include the `NODE_OPTIONS="--openssl-legacy-provider"` workaround for OpenSSL compatibility. This is also marked as a temporary fix.