### PR TITLE
refactor: 💡 Dockerfile での ENV の書き方を推奨の形に変更した

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 FROM ruby:3.4.3
-ENV LANG C.UTF-8
+ENV LANG=C.UTF-8
 ARG NODEJS_VERSION
 
 RUN apt update -qq && apt install -y build-essential libpq-dev


### PR DESCRIPTION
"ENV HOGE FUGA" -> "ENV HOGE=FUGA"
